### PR TITLE
Model edit improvements

### DIFF
--- a/lib/formtools/form.js
+++ b/lib/formtools/form.js
@@ -62,6 +62,10 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
             // handle list types
             function (callback) {
 
+                if (field.visible === false) {
+                    return callback(null);
+                }
+
                 // determine if the field has enumValues
                 if (Array.isArray(field.list) && field.list.length) {
 
@@ -106,6 +110,10 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
             // handle defaultValues
             function (callback) {
 
+                if (field.visible === false) {
+                    return callback(null);
+                }
+
                 defaultValue = formtoolUtils.getDefaultValue(m.paths[fieldName]);
 
                 return callback(null);
@@ -114,6 +122,10 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
 
             // handle ref fields
             function (callback) {
+
+                if (field.visible === false) {
+                    return callback(null);
+                }
 
                 // if the field has a reference, we need to grab the values for that type and add them in
                 // if not, skip this function
@@ -176,16 +188,25 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
             // handle embedded documents
             function (callback) {
 
-                if (field.type !== 'documentarray') {
+                if (field.visible === false || field.type !== 'documentarray') {
                     return callback(null);
+                }
+
+                if (!field.schema.statics.getForm) {
+                    return callback(new Error('Unable to locate the form settings for the field \'' + fieldName + '\' which contains an embedded document schema. Please make sure you have added Linz formtools.plugins.embeddedDocument against the schema for the embedded document.'));
                 }
 
                 field.schema.statics.getForm(function (err, f) {
 
                     // render the form to pass into the template
-                    generateFormFromModel(field.schema, f, {}, formType, function (emdeddedForm) {
+                    generateFormFromModel(field.schema, f, {}, formType, function (getEmbeddedFormErr, emdeddedForm) {
+
+                        if (getEmbeddedFormErr) {
+                            return callback(getEmbeddedFormErr);
+                        }
 
                         embeddedDocumentForm = emdeddedForm;
+
                         return callback(null);
 
                     });
@@ -333,14 +354,14 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
             }
         ], function (err, results) {
 
-            fn(null);
+            fn(err);
 
         });
 
 
     }, function (err) {
 
-        cb(form);
+        cb(err, form);
 
     });
 

--- a/lib/formtools/form.js
+++ b/lib/formtools/form.js
@@ -43,28 +43,37 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
     // defaults to 'create'
     formType = formType || 'create';
 
-    async.eachSeries(Object.keys(schemaFields), function (fieldName, fn) {
+    // remove fields that are set to be omitted from the form
+    Object.keys(schemaFields).forEach(function (fieldName) {
 
         var field = clone(schemaFields[fieldName]); // we're going to make changes to this object, clone don't reference the original value
-        var fieldOptions = field.options;
-        var formField;
-        var choices = {};
-        var defaultValue = null;
-        var embeddedDocumentForm = null;
 
         // merge form.edit or form.create onto form
         utils.merge(field, field[formType] || {});
         delete field.edit;
         delete field.create;
 
+        if (field.visible === false) {
+            return;
+        }
+
+        formFields[fieldName] = field;
+
+    });
+
+    async.eachSeries(Object.keys(formFields), function (fieldName, fn) {
+
+        var field = formFields[fieldName];
+        var fieldOptions = field.options;
+        var formField;
+        var choices = {};
+        var defaultValue = null;
+        var embeddedDocumentForm = null;
+
         async.series([
 
             // handle list types
             function (callback) {
-
-                if (field.visible === false) {
-                    return callback(null);
-                }
 
                 // determine if the field has enumValues
                 if (Array.isArray(field.list) && field.list.length) {
@@ -110,10 +119,6 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
             // handle defaultValues
             function (callback) {
 
-                if (field.visible === false) {
-                    return callback(null);
-                }
-
                 defaultValue = formtoolUtils.getDefaultValue(m.paths[fieldName]);
 
                 return callback(null);
@@ -122,10 +127,6 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
 
             // handle ref fields
             function (callback) {
-
-                if (field.visible === false) {
-                    return callback(null);
-                }
 
                 // if the field has a reference, we need to grab the values for that type and add them in
                 // if not, skip this function
@@ -188,7 +189,7 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
             // handle embedded documents
             function (callback) {
 
-                if (field.visible === false || field.type !== 'documentarray') {
+                if (field.type !== 'documentarray') {
                     return callback(null);
                 }
 
@@ -217,10 +218,6 @@ var generateFormFromModel = exports.generateFormFromModel = function (m, schemaF
 
             // create form elements where neccessary
             function (callback) {
-
-                if (field.visible === false) {
-                    return callback(null);
-                }
 
                 var fieldValue;
 

--- a/middleware-public/error.js
+++ b/middleware-public/error.js
@@ -2,7 +2,7 @@ linz = require('../');
 
 module.exports = function (err, req, res, next) {
 
-    console.error(err);
+    console.error(err.stack);
 
     res.render(linz.views + '/error.jade', {
         error: err,

--- a/routes/configEdit.js
+++ b/routes/configEdit.js
@@ -1,9 +1,13 @@
 var linz = require('../');
 
 /* GET /admin/config/:config/overview */
-var route = function (req, res) {
+var route = function (req, res, next) {
 
-	linz.formtools.form.generateFormFromModel(req.linz.config.schema, req.linz.config.form, req.linz.record, 'edit', function (editForm) {
+	linz.formtools.form.generateFormFromModel(req.linz.config.schema, req.linz.config.form, req.linz.record, 'edit', function (err, editForm) {
+
+		if (err) {
+			return next(err);
+		}
 
 		res.render(linz.views + '/configEdit.jade', {
 			record: req.linz.record,

--- a/routes/modelCreate.js
+++ b/routes/modelCreate.js
@@ -2,9 +2,13 @@ var linz = require('../'),
     inflection = require('inflection');
 
 /* GET /admin/model/:model/create */
-var route = function (req, res) {
+var route = function (req, res, next) {
 
-	linz.formtools.form.generateFormFromModel(req.linz.model.schema, req.linz.model.form, {}, 'create', function (editForm) {
+	linz.formtools.form.generateFormFromModel(req.linz.model.schema, req.linz.model.form, {}, 'create', function (err, editForm) {
+
+        if (err) {
+            return next(err);
+        }
 
 		res.render(req.linz.views + '/modelCreate.jade', {
 			model: req.linz.model,

--- a/routes/recordEdit.js
+++ b/routes/recordEdit.js
@@ -2,9 +2,13 @@ var formist = require('formist'),
 	linz = require('../');
 
 /* GET /admin/:model/:id/overview */
-var route = function (req, res) {
+var route = function (req, res, next) {
 
-	linz.formtools.form.generateFormFromModel(req.linz.model.schema, req.linz.model.form, req.linz.record, 'edit', function (editForm) {
+	linz.formtools.form.generateFormFromModel(req.linz.model.schema, req.linz.model.form, req.linz.record, 'edit', function (err, editForm) {
+
+		if (err) {
+			return next(err);
+		}
 
 		res.render(req.linz.views + '/recordEdit.jade', {
 			model: req.linz.model,


### PR DESCRIPTION
This PR fixes the following:

- [x] Formtools form generator
 - [x] Update ```generateFormFromModel()``` function to exclude fields where ```field.visible === false``` first and only process visible fields
 - [x] Enable the form builder to pass the error back to the router which can be pushed to express error handler. Currently any errors occurred in the form builder is concealed.
 - [x] Throw error if a form field is of type ```documentArray``` and it's not bind to the Linz embeddedDocument plugin
- [x] Updated express error handler to output the error stack to console

@smebberson This is ready for review!