### PR TITLE
Added a route to output a JSON string for configs and model records.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -56,6 +56,7 @@ exports.setupModelRoutes = function () {
 	router.get('/model/:model/:id/edit', middleware.recordEdit(), routes.recordEdit);
 	router.post('/model/:model/:id/save', middleware.recordSave(), routes.recordSave);
 	router.get('/model/:model/:id/delete', middleware.recordDelete(), routes.recordDelete);
+	router.get('/model/:model/:id/json', routes.recordJSON);
 
 };
 
@@ -67,6 +68,7 @@ exports.setupConfigsRoutes = function () {
     router.get('/config/:config/edit', middleware.configEdit(), routes.configEdit);
     router.post('/config/:config/save', middleware.configSave(), routes.configSave);
     router.get('/config/:config/default', middleware.configDefault(), routes.configDefault);
+    router.get('/config/:config/json', routes.configJSON);
 
 };
 
@@ -75,4 +77,3 @@ exports.setupLoggingRoutes = function (logPath) {
     router.get('/logs/request/list', middleware.requestLog(logPath), routes.requestLog);
 
 };
-

--- a/routes/configJSON.js
+++ b/routes/configJSON.js
@@ -1,0 +1,24 @@
+var linz = require('../');
+
+/* GET /admin/config/:config/json */
+var route = function (req, res, next) {
+
+    req.linz.config = linz.get('configs')[req.params.config];
+
+    linz.mongoose.connection.db.collection(linz.get('configs collection name'), function (err, collection) {
+
+        collection.findOne({ _id: req.params.config}, function (err, doc) {
+
+            if (err) {
+                return next(err);
+            }
+
+            return res.json(doc);
+
+        });
+
+    });
+
+}
+
+module.exports = route;

--- a/routes/recordJSON.js
+++ b/routes/recordJSON.js
@@ -1,0 +1,20 @@
+
+/* GET /admin/:model/:id/json */
+var route = function (req, res, next) {
+
+    req.linz.model = req.linz.get('models')[req.params.model];
+
+    // get doc
+    req.linz.model.findById(req.params.id, function (err, doc) {
+
+        if (err) {
+            return next(err);
+        }
+
+        res.json(doc);
+
+    });
+
+}
+
+module.exports = route;


### PR DESCRIPTION
As per the title, this allows you to easily access the raw JSON data for a model record, or a config. Simply replace `overview` at the end of a record overview with `json` to see the output.

I've decided not to create a model overview action 'button' for this, until we have the capability to lock down actions to certain user groups. I don't think everyone should have a button on the overview screen for this, although I don't mind them having access to the raw data.

@sandytrinh, this is ready for review.