### PR TITLE
Pass mongoose objects to model index renderers, rather than object literals

### DIFF
--- a/middleware/_modelIndex.js
+++ b/middleware/_modelIndex.js
@@ -279,6 +279,9 @@ module.exports = function  (req, res, next) {
                     // loop through each record
                     async.each(Object.keys(records), function (index, recordDone) {
 
+                        // store the rendered content into a separate property
+                        records[index]['rendered'] = {};
+
                         // loop through each column
                         async.each(Object.keys(req.linz.model.grid.columns), function (column, columnDone) {
 
@@ -289,13 +292,13 @@ module.exports = function  (req, res, next) {
                                 args.push(records[index][column]);
                             }
 
-                            args.push(records[index]);
+                            args.push(mongooseRecords[index]);
                             args.push(column);
                             args.push(req.linz.model);
                             args.push(function (err, value) {
 
                                 if (!err) {
-                                    records[index][column] = value;
+                                    records[index]['rendered'][column] = value;
                                 }
 
                                 return columnDone(err);
@@ -337,13 +340,13 @@ module.exports = function  (req, res, next) {
                             throw new Error('Invalid type for record.action.disabled. It must be a function');
                         }
 
-                        async.each(records, function (record, recordDone) {
+                        async.each(Object.keys(records), function (index, recordDone) {
 
-                            action.disabled(record, function (err, isDisabled, message) {
+                            action.disabled(mongooseRecords[index], function (err, isDisabled, message) {
 
-                                record.recordActions = record.recordActions || {};
+                                records[index].recordActions = records[index].recordActions || {};
 
-                                record.recordActions[action.label] = {
+                                records[index].recordActions[action.label] = {
                                     disabled: isDisabled,
                                     message: message
                                 };

--- a/views/modelIndex/records.jade
+++ b/views/modelIndex/records.jade
@@ -56,4 +56,4 @@ if records.length > 0
 																	a(href=linz.api.getAdminLink(model, action.action, record._id))= action.label
 
 							each val in Object.keys(model.grid.columns)
-								td!= record[val]
+								td!= record['rendered'][val]


### PR DESCRIPTION
One of the features of mongoose is the ability to have model statics and methods. It's great and allows you to contextify additional functionality to a model quite easily.

When rendering the model index page, we turn the mongoose object into an object literal so that we can attach extra properties to the object (mongoose objects don't allow this). The extra properties are used when rendering the model index page in jade.

This change provides mongoose objects to model index renderers, and provides object literals with extra properties to jade for rendering.

@sandytrinh, this PR is ready for review.