### PR TITLE
Multiple exports for a model

### DIFF
--- a/lib/formtools/plugins/plugins-helpers.js
+++ b/lib/formtools/plugins/plugins-helpers.js
@@ -91,17 +91,7 @@ var defaults = function (options, isEmbeddedDocument) {
     options.grid.recordActions = options.grid.recordActions || [];
 
     // defaults to []
-    options.grid.export = options.grid.export || [];
-
-    options.grid.export.label = options.grid.export.label || 'Export';
-
-    options.grid.export.action = options.grid.export.action || 'export';
-
-    // defaults to false
-    options.grid.export.enable = (options.grid.export.enable === true);
-
-    options.grid.export.exclusions = options.grid.export.exclusions || '_id,dateCreated,dateModified,createdBy,modifiedBy';
-
+    options.grid.export = exportDefault(options.grid.export) || [];
 
     /**
     * overview defaults
@@ -249,6 +239,50 @@ var filtersDefault = function (filters) {
     });
 
     return filters;
+
+};
+
+var exportDefault = function (exports) {
+
+    if (exports === undefined || exports === null) {
+        return undefined;
+    }
+
+    var validatedExports = [];
+
+    // linz will accept an object, or an array of objects
+    if (!Array.isArray(exports)) {
+        exports = [exports];
+    }
+
+    // loop through each export, and default some values
+    exports.forEach(function (exp) {
+
+        // we must have a label, otherwise there is not enough information
+        if (!exp.label) {
+            return;
+        }
+
+        if (exp.action && exp.action === 'export') {
+            throw new Error('You can not define a model export with an action property of export, this is reserved for Linz.');
+        }
+
+        var expObj = {
+                label: exp.label,
+                action: exp.action || 'export',
+                enabled: !(exp.enable === true),
+                exclusions: exp.exclusions || '_id,dateCreated,dateModified,createdBy,modifiedBy'
+            };
+
+        // Linz's built in action is called export
+        expObj.custom = expObj.action !== 'export';
+
+        // push this into the list of exports
+        validatedExports.push(expObj);
+
+    });
+
+    return validatedExports;
 
 };
 

--- a/middleware/modelExport.js
+++ b/middleware/modelExport.js
@@ -225,6 +225,31 @@ var modelExportHelpers = function modelExportHelpers (req, res) {
 
 }
 
+// this will retrieve the export object, using Linz's default export handler amongst custom export handlers
+// this is based on the knowledge that only Linz's default export handler can have an `action` of `export`
+// `exports` should be model.grid.export
+var getExport = function (exports) {
+
+    var exp = undefined;
+
+    // retrieve the export object
+    exports.forEach(function (_export) {
+
+        // Linz's default export function is called export
+        if (_export.action && _export.action === 'export') {
+            exp = _export;
+        }
+
+    });
+
+    // if the export object could not be found, throw an error
+    if (!exp) {
+        throw new Error('The export was using Linz default export method, yet the model\'s grid.export object could not be found.');
+    }
+
+    return exp;
+
+}
 
 module.exports = {
 
@@ -238,17 +263,22 @@ module.exports = {
                 return next(err);
             }
 
+            // attach our grid object to the model
             req.linz.model.grid = grid;
-            req.linz.model.grid.export.fields = {};
 
+            // retrieve the export object
+            req.linz.export = getExport(grid.export);
+            req.linz.export.fields = {};
+
+            // retrieve the form to provide a list of fields to choose from
             req.linz.model.getForm( function (formErr, form){
 
                 if (formErr) {
                     return next(formErr);
                 }
 
-                var excludedFieldNames = grid.export.exclusions.concat(',__v').split(','),
-                fieldLabels = {};
+                var excludedFieldNames = req.linz.export.exclusions.concat(',__v').split(','),
+                    fieldLabels = {};
 
                 // get a list of field names
                 req.linz.model.schema.eachPath(function (pathname, schemaType) {
@@ -268,7 +298,7 @@ module.exports = {
 
                 // iterate through sorted label and re-constructs in the order of labels
                 sortedFieldsByLabel.forEach(function (label) {
-                    req.linz.model.grid.export.fields[fieldLabels[label]] = label;
+                    req.linz.export.fields[fieldLabels[label]] = label;
                 });
 
                 return next(null);
@@ -298,7 +328,18 @@ module.exports = {
         asyncFn.push(helpers.getForm);
         asyncFn.push(helpers.getGrid);
 
-        async.waterfall(asyncFn, function (err, filters, form, grid) {
+        // get the actual export object
+        asyncFn.push(function (filters, form, grid, callback) {
+
+            // retrieve the export
+            var _export = getExport(grid.export);
+            _export.fields = {};
+
+            return callback(null, filters, form, grid, _export);
+
+        });
+
+        async.waterfall(asyncFn, function (err, filters, form, grid, exportObj) {
 
             if (err) {
                 return next(err);
@@ -325,7 +366,7 @@ module.exports = {
             });
 
             // check if _id is excluded
-            if (grid.export.exclusions.indexOf('_id') >= 0) {
+            if (exportObj.exclusions.indexOf('_id') >= 0) {
                 filterFieldNames.push('-_id');
             }
 

--- a/public/js/model/index.js
+++ b/public/js/model/index.js
@@ -185,7 +185,7 @@
     });
 
     // bind export button
-    $('[data-linz-control="export"]').click(function () {
+    $('[data-linz-control="export"][data-target="#exportModal"]').click(function () {
 
         var queryObj = $(this),
             url = queryObj.attr('href');

--- a/routes/modelExport.js
+++ b/routes/modelExport.js
@@ -3,7 +3,7 @@ var linz = require('../');
 module.exports = {
 
     get: function (req, res) {
-        res.render(linz.views + '/modelExport.jade', { model: req.linz.model });
+        res.render(linz.views + '/modelExport.jade', { model: req.linz.model, modelExport: req.linz.export });
     }
 
 }

--- a/views/modelExport.jade
+++ b/views/modelExport.jade
@@ -1,10 +1,10 @@
 extends modal
 
 block content
-	form.exportForm(role='form', action=linz.api.getAdminLink(model, model.grid.export.action), method='post', target='_blank')
+	form.exportForm(role='form', action=linz.api.getAdminLink(model, modelExport.action), method='post', target='_blank')
 		div.modal-header
 			button.close(type='button', data-dismiss='modal' aria-hidden='true') &times;
-			h4#myModalLabel.modal-title!= model.grid.export.label
+			h4#myModalLabel.modal-title!= modelExport.label
 		div.modal-body
 			div.modal-footer.actions
 				button.btn.btn-default(type='button', class='pull-left', data-linz-control="checked-all") Select <b>all</b>
@@ -30,7 +30,7 @@ block content
 
 		(function () {
 
-			var fields = !{JSON.stringify(model.grid.export.fields)},
+			var fields = !{JSON.stringify(modelExport.fields)},
 				exportCookieName = !{JSON.stringify(model.modelName)} + '_' + 'selectedExportFields',
 				savedFields = mergeFields(getCookie(exportCookieName), fields),
 				bSelectAll = true;

--- a/views/modelIndex/header.jade
+++ b/views/modelIndex/header.jade
@@ -41,6 +41,22 @@
 									- groupAction.attributes['data-target'] = '#groupActionModal'
 								a(role='menuitem' tabindex='-1' href=linz.api.getAdminLink(model, groupAction.action))&attributes(groupAction.attributes)= groupAction.label
 
-	if model.grid.export && model.grid.export.enable
+	if model.grid.export && model.grid.export.length
 		.export
-			a.btn.btn-default(href='' + linz.api.getAdminLink(model, model.grid.export.action) data-linz-control="export" data-target="#exportModal")= model.grid.export.label
+			if model.grid.export.length === 1
+				for exp in model.grid.export
+					if exp.enabled
+						a.btn.btn-default(href='' + linz.api.getAdminLink(model, exp.action) data-linz-control="export" data-target="#exportModal")= exp.label
+			else
+				.dropdown
+					button.btn.btn-default.dropdown-toggle(type='button', data-toggle='dropdown')
+						| Export&nbsp;
+						span.caret
+					ul.dropdown-menu(role='menu')
+						for exp in model.grid.export
+							if exp.enabled
+								- attributes = {}
+								if exp.action === 'export'
+									- attributes['data-target'] = '#exportModal'
+								li(role='presentation')
+									a(role='menuitem' tabindex='-1' href='' + linz.api.getAdminLink(model, exp.action) data-linz-control='export')&attributes(attributes)= exp.label


### PR DESCRIPTION
Linz's default model export functionality is pretty good, but there are times when you just want to do something different.

This PR provides the ability to either completely overwrite the default export capability, or supplement it with another export option for your users.

Todo
-------

- [x] Update Linz to accept either an object or an array
- [x] Update the model index to show a drop-down list if there are multiple exports
- [x] Ensure that custom export routines can't use `action` with a value of `export` (this has been reserved for Linz)
- [ ] Update the tests to ensure we have test coverage for this

Usage
---------

To use this functionality, add an `export` property to your model's `grid` property:

```
    grid: {
        export: [
            {
                label: 'Custom export',
                action: 'url/endpoint'
            }
        ]
    }
```

To use a custom export, along with Linz's default export:

```
    grid: {
        export: [
            {
                label: 'Export',
                exclusions: 'fields,to,exclude'
            },
            {
                label: 'Custom export',
                action: 'url/endpoint'
            }
        ]
    }
```

Providing an export definition with an `action` value of `export` will error, for example:

```
    grid: {
        export: [
            {
                label: 'Export',
                action: 'export'
            }
        ]
    }
```
