### PR TITLE
Custom exports

### DIFF
--- a/lib/formtools/plugins/plugins-helpers.js
+++ b/lib/formtools/plugins/plugins-helpers.js
@@ -91,17 +91,7 @@ var defaults = function (options, isEmbeddedDocument) {
     options.grid.recordActions = options.grid.recordActions || [];
 
     // defaults to []
-    options.grid.export = options.grid.export || [];
-
-    options.grid.export.label = options.grid.export.label || 'Export';
-
-    options.grid.export.action = options.grid.export.action || 'export';
-
-    // defaults to false
-    options.grid.export.enable = (options.grid.export.enable === true);
-
-    options.grid.export.exclusions = options.grid.export.exclusions || '_id,dateCreated,dateModified,createdBy,modifiedBy';
-
+    options.grid.export = exportDefault(options.grid.export) || [];
 
     /**
     * overview defaults
@@ -249,6 +239,50 @@ var filtersDefault = function (filters) {
     });
 
     return filters;
+
+};
+
+var exportDefault = function (exports) {
+
+    if (!exports) {
+        return undefined;
+    }
+
+    var validatedExports = [];
+
+    // linz will accept an object, or an array of objects
+    if (!Array.isArray(exports)) {
+        exports = [exports];
+    }
+
+    // loop through each export, and default some values
+    exports.forEach(function (exp) {
+
+        // we must have a label, otherwise there is not enough information
+        if (!exp.label) {
+            return;
+        }
+
+        if (exp.action && exp.action === 'export') {
+            throw new Error('You can not define a model export with an action property of export, this is reserved for Linz.');
+        }
+
+        var expObj = {
+                label: exp.label,
+                action: exp.action || 'export',
+                enabled: !(exp.enable === true),
+                exclusions: exp.exclusions || '_id,dateCreated,dateModified,createdBy,modifiedBy'
+            };
+
+        // Linz's built in action is called export
+        expObj.custom = expObj.action !== 'export';
+
+        // push this into the list of exports
+        validatedExports.push(expObj);
+
+    });
+
+    return validatedExports;
 
 };
 

--- a/middleware/modelExport.js
+++ b/middleware/modelExport.js
@@ -109,12 +109,12 @@ var modelExportHelpers = function modelExportHelpers (req, res) {
 
         getFilters: function getFilters (cb) {
 
-            if (!req.body.modelQuery.length) {
+            if (!req.body.filters.length) {
                 return cb(null, {});
             }
 
             var Model = linz.get('models')[req.body.modelName],
-                form = JSON.parse(req.body.modelQuery);
+                form = JSON.parse(req.body.filters);
 
             // check if there are any filters in the form post
             if (!form.selectedFilters) {
@@ -225,6 +225,31 @@ var modelExportHelpers = function modelExportHelpers (req, res) {
 
 }
 
+// this will retrieve the export object, using Linz's default export handler amongst custom export handlers
+// this is based on the knowledge that only Linz's default export handler can have an `action` of `export`
+// `exports` should be model.grid.export
+var getExport = function (exports) {
+
+    var exp = undefined;
+
+    // retrieve the export object
+    exports.forEach(function (_export) {
+
+        // Linz's default export function is called export
+        if (_export.action && _export.action === 'export') {
+            exp = _export;
+        }
+
+    });
+
+    // if the export object could not be found, throw an error
+    if (!exp) {
+        throw new Error('The export was using Linz default export method, yet the model\'s grid.export object could not be found.');
+    }
+
+    return exp;
+
+}
 
 module.exports = {
 
@@ -238,17 +263,22 @@ module.exports = {
                 return next(err);
             }
 
+            // attach our grid object to the model
             req.linz.model.grid = grid;
-            req.linz.model.grid.export.fields = {};
 
+            // retrieve the export object
+            req.linz.export = getExport(grid.export);
+            req.linz.export.fields = {};
+
+            // retrieve the form to provide a list of fields to choose from
             req.linz.model.getForm( function (formErr, form){
 
                 if (formErr) {
                     return next(formErr);
                 }
 
-                var excludedFieldNames = grid.export.exclusions.concat(',__v').split(','),
-                fieldLabels = {};
+                var excludedFieldNames = req.linz.export.exclusions.concat(',__v').split(','),
+                    fieldLabels = {};
 
                 // get a list of field names
                 req.linz.model.schema.eachPath(function (pathname, schemaType) {
@@ -268,7 +298,7 @@ module.exports = {
 
                 // iterate through sorted label and re-constructs in the order of labels
                 sortedFieldsByLabel.forEach(function (label) {
-                    req.linz.model.grid.export.fields[fieldLabels[label]] = label;
+                    req.linz.export.fields[fieldLabels[label]] = label;
                 });
 
                 return next(null);
@@ -298,7 +328,18 @@ module.exports = {
         asyncFn.push(helpers.getForm);
         asyncFn.push(helpers.getGrid);
 
-        async.waterfall(asyncFn, function (err, filters, form, grid) {
+        // get the actual export object
+        asyncFn.push(function (filters, form, grid, callback) {
+
+            // retrieve the export
+            var _export = getExport(grid.export);
+            _export.fields = {};
+
+            return callback(null, filters, form, grid, _export);
+
+        });
+
+        async.waterfall(asyncFn, function (err, filters, form, grid, exportObj) {
 
             if (err) {
                 return next(err);
@@ -325,7 +366,7 @@ module.exports = {
             });
 
             // check if _id is excluded
-            if (grid.export.exclusions.indexOf('_id') >= 0) {
+            if (exportObj.exclusions.indexOf('_id') >= 0) {
                 filterFieldNames.push('-_id');
             }
 

--- a/middleware/modelExport.js
+++ b/middleware/modelExport.js
@@ -313,11 +313,6 @@ module.exports = {
 
         var Model = linz.get('models')[req.body.modelName];
 
-        // check if there is custom export function for model
-        if (Model.export) {
-            return Model.export(req, res, next);
-        }
-
         // since a custom export function is not defined for model, use local export function
         var asyncFn = [],
             helpers = modelExportHelpers(req, res),

--- a/public/js/model/index.js
+++ b/public/js/model/index.js
@@ -185,12 +185,55 @@
     });
 
     // bind export button
-    $('[data-linz-control="export"]').click(function () {
+    $('[data-linz-control="export"]').click(function (event) {
+
+        // stop the href navigation
+        event.preventDefault();
 
         var queryObj = $(this),
-            url = queryObj.attr('href');
+            url = queryObj.attr('href'),
+            useModal = (queryObj.attr('data-target') === "#exportModal");
 
-        $('#exportModal').modal().find('.modal-dialog').load(url, function () {});
+        if (useModal) {
+            $('#exportModal').modal().find('.modal-dialog').load(url, function () {});
+            return false;
+        }
+
+        // retrieve the ids
+        var selectedIds = $('input[data-linz-control="checked-record"]:checked').map(function () {
+            return $(this).val();
+        }).get();
+
+        // construct the form
+        var form = document.createElement('form');
+        form.method = 'post';
+        form.action = url;
+
+        var inputFilters = document.createElement('input');
+        inputFilters.type = 'hidden';
+        inputFilters.name = 'filters';
+        inputFilters.value = $('#modelQuery').html();
+
+        var inputSelectedIds = document.createElement('input')
+        inputSelectedIds.type = 'hidden';
+        inputSelectedIds.name = 'selectedIds';
+        inputSelectedIds.value = selectedIds.join(',');
+
+        var inputModelName = document.createElement('input');
+        inputModelName.type = 'hidden';
+        inputModelName.name = 'modelName';
+        inputModelName.value = $('[data-linz-model]').attr('data-linz-model');
+
+        // append to the form
+        form.appendChild(inputFilters);
+        form.appendChild(inputSelectedIds);
+        form.appendChild(inputModelName);
+
+        // append form to body
+        document.body.appendChild(form);
+
+        // submit the form
+        form.submit();
 
         return false;
 
@@ -207,10 +250,13 @@
         });
 
         // add selected IDs to hidden field
-        $(_this).find('[data-export="ids"]').val(selectedIDs);
+        $(_this).find('[data-linz-export="ids"]').val(selectedIDs);
 
         // add model form post data for filtering purposes
-        $(_this).find('[data-export="modelQuery"]').val($('#modelQuery').html());
+        $(_this).find('[data-linz-export="filters"]').val($('#modelQuery').html());
+
+        // add the model name
+        $(_this).find('[data-linz-export="model"]').val($('[data-linz-model]').attr('data-linz-model'));
 
     });
 

--- a/routes/modelExport.js
+++ b/routes/modelExport.js
@@ -3,7 +3,7 @@ var linz = require('../');
 module.exports = {
 
     get: function (req, res) {
-        res.render(linz.views + '/modelExport.jade', { model: req.linz.model });
+        res.render(linz.views + '/modelExport.jade', { model: req.linz.model, modelExport: req.linz.export });
     }
 
 }

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,7 +1,10 @@
 include mixins/navigation
 
 doctype html
-html(lang="en")
+- attributes = []
+if model && model.modelName
+	- attributes['data-linz-model'] = model.modelName
+html(lang="en")&attributes(attributes)
 	head
 		title= pageTitle
 		meta(name='viewport', content='width=device-width, initial-scale=1.0')

--- a/views/modelExport.jade
+++ b/views/modelExport.jade
@@ -1,10 +1,10 @@
 extends modal
 
 block content
-	form.exportForm(role='form', action=linz.api.getAdminLink(model, model.grid.export.action), method='post', target='_blank')
+	form.exportForm(role='form', action=linz.api.getAdminLink(model, modelExport.action), method='post', target='_blank')
 		div.modal-header
 			button.close(type='button', data-dismiss='modal' aria-hidden='true') &times;
-			h4#myModalLabel.modal-title!= model.grid.export.label
+			h4#myModalLabel.modal-title!= modelExport.label
 		div.modal-body
 			div.modal-footer.actions
 				button.btn.btn-default(type='button', class='pull-left', data-linz-control="checked-all") Select <b>all</b>
@@ -12,10 +12,10 @@ block content
 				button.btn.btn-primary(type='submit', data-linz-control='export-save') Export
 				button.btn.btn-default(type='button', data-dismiss='modal') Cancel
 
-			input(type='hidden', name='modelName', value=model.modelName)
-			input(type='hidden', name='selectedIds', data-export='ids')
-			input(type='hidden', name='selectedFields', data-export='fields')
-			input(type='hidden', name='modelQuery', data-export='modelQuery')
+			input(type='hidden', name='modelName', data-linz-export='model')
+			input(type='hidden', name='selectedIds', data-linz-export='ids')
+			input(type='hidden', name='selectedFields', data-linz-export='fields')
+			input(type='hidden', name='filters', data-linz-export='filters')
 
 			p Drag and drop to re-order the fields.
 
@@ -30,7 +30,7 @@ block content
 
 		(function () {
 
-			var fields = !{JSON.stringify(model.grid.export.fields)},
+			var fields = !{JSON.stringify(modelExport.fields)},
 				exportCookieName = !{JSON.stringify(model.modelName)} + '_' + 'selectedExportFields',
 				savedFields = mergeFields(getCookie(exportCookieName), fields),
 				bSelectAll = true;
@@ -81,7 +81,7 @@ block content
 
 			$('.exportForm').submit(function (event){
 
-				$('[data-export="fields"]').val(getSelectedExportFields().join());
+				$('[data-linz-export="fields"]').val(getSelectedExportFields().join());
 
 			});
 

--- a/views/modelIndex/header.jade
+++ b/views/modelIndex/header.jade
@@ -41,6 +41,22 @@
 									- groupAction.attributes['data-target'] = '#groupActionModal'
 								a(role='menuitem' tabindex='-1' href=linz.api.getAdminLink(model, groupAction.action))&attributes(groupAction.attributes)= groupAction.label
 
-	if model.grid.export && model.grid.export.enable
+	if model.grid.export && model.grid.export.length
 		.export
-			a.btn.btn-default(href='' + linz.api.getAdminLink(model, model.grid.export.action) data-linz-control="export" data-target="#exportModal")= model.grid.export.label
+			if model.grid.export.length === 1
+				for exp in model.grid.export
+					if exp.enabled
+						a.btn.btn-default(href='' + linz.api.getAdminLink(model, exp.action) data-linz-control="export" data-target="#exportModal")= exp.label
+			else
+				.dropdown
+					button.btn.btn-default.dropdown-toggle(type='button', data-toggle='dropdown')
+						| Export&nbsp;
+						span.caret
+					ul.dropdown-menu(role='menu')
+						for exp in model.grid.export
+							if exp.enabled
+								- attributes = {}
+								if exp.action === 'export'
+									- attributes['data-target'] = '#exportModal'
+								li(role='presentation')
+									a(role='menuitem' tabindex='-1' href='' + linz.api.getAdminLink(model, exp.action) data-linz-control='export')&attributes(attributes)= exp.label

--- a/views/modelIndex/header.jade
+++ b/views/modelIndex/header.jade
@@ -46,7 +46,10 @@
 			if model.grid.export.length === 1
 				for exp in model.grid.export
 					if exp.enabled
-						a.btn.btn-default(href='' + linz.api.getAdminLink(model, exp.action) data-linz-control="export" data-target="#exportModal")= exp.label
+						- attributes = {}
+						if exp.action === 'export'
+							- attributes['data-target'] = '#exportModal'
+						a.btn.btn-default(href='' + linz.api.getAdminLink(model, exp.action) data-linz-control="export")&attributes(attributes)= exp.label
 			else
 				.dropdown
 					button.btn.btn-default.dropdown-toggle(type='button', data-toggle='dropdown')


### PR DESCRIPTION
This PR is stage 1 of a two stage improvement to Linz in which custom exports will be supported. Stages are broken down into:

1. the ability to define a custom export that doesn't require a modal UI step (as per the default Linz export)
1. the ability to define a custom export that does require a modal UI step

Stage 2 will be implemented in a separate PR.

Linz's default model export functionality is pretty good, but there are times when you just want to do something different. This PR provides the ability to either completely overwrite the default export capability, or supplement it with another export option for your users.

Todo
-------

- [x] Update Linz to accept either an object or an array for the grid.export property
- [x] Update the model index to show a drop-down list if there are multiple exports
- [x] Ensure that custom export routines can't use `action` with a value of `export` (this has been reserved for Linz)
- [ ] Update the tests to ensure we have test coverage for this

Usage
---------

To use this functionality, add an `export` property to your model's `grid` property:

```
    grid: {
        export: [
            {
                label: 'Custom export',
                action: 'url/endpoint'
            }
        ]
    }
```

To use a custom export, along with Linz's default export:

```
    grid: {
        export: [
            {
                label: 'Export',
                exclusions: 'fields,to,exclude'
            },
            {
                label: 'Custom export',
                action: 'url/endpoint'
            }
        ]
    }
```

Providing an export definition with an `action` value of `export` will error, for example:

```
    grid: {
        export: [
            {
                label: 'Export',
                action: 'export'
            }
        ]
    }
```
