### PR TITLE
Improves linz modal support

### DIFF
--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -121,26 +121,36 @@ if (!linz) {
         });
 
         // add ability to open URL in a modal
-        $('[data-linz-modal]').click(function () {
+        $('[data-linz-modal]').click(function (event) {
 
-            if ($(this).attr('data-linz-disabled') === 'true') {
+            event.preventDefault();
+
+            var button = $(this);
+
+            if (button.attr('data-linz-disabled') === 'true') {
                 return;
             }
 
-            var queryObj = $(this),
-                url = queryObj[0].nodeName === 'BUTTON' ? queryObj.attr('data-href') : queryObj.attr('href');
+            var url = button[0].nodeName === 'BUTTON' ? button.attr('data-href') : button.attr('href');
 
-            $('#linzModal').modal().load(url, function () {});
+            // open modal and load URL
+            $('#linzModal').modal().load(url);
 
-           return false;
+            // remove modal shown event
+            $('#linzModal').off('shown.bs.modal');
 
-        });
+            // re-bind the shown event
+            $('#linzModal').on('shown.bs.modal', function (e) {
 
-        // bind model save button and update the selected ids to modal form
-        $('#linzModal').on('shown.bs.modal', function (e) {
+                // add form validation
+                $(this).find('form[data-linz-validation="true"]').bootstrapValidator({});
 
-            // add form validation
-            $(this).find('form[data-linz-validation="true"]').bootstrapValidator({});
+                if (button.attr('data-linz-modal-callback')) {
+                    // run custom function if provided after modal is shown
+                    window[button.attr('data-linz-modal-callback')]();
+                }
+
+            });
 
         });
 

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -120,6 +120,30 @@ if (!linz) {
 
         });
 
+        // add ability to open URL in a modal
+        $('[data-linz-modal]').click(function () {
+
+            if ($(this).attr('data-linz-disabled') === 'true') {
+                return;
+            }
+
+            var queryObj = $(this),
+                url = queryObj[0].nodeName === 'BUTTON' ? queryObj.attr('data-href') : queryObj.attr('href');
+
+            $('#linzModal').modal().load(url, function () {});
+
+           return false;
+
+        });
+
+        // bind model save button and update the selected ids to modal form
+        $('#linzModal').on('shown.bs.modal', function (e) {
+
+            // add form validation
+            $(this).find('form[data-linz-validation="true"]').bootstrapValidator({});
+
+        });
+
     });
 
     function loadLibraries(path) {

--- a/routes/modelIndex.js
+++ b/routes/modelIndex.js
@@ -24,6 +24,22 @@ var route = function (req, res) {
         sortDirection = ((req.linz.model.formData.sort.charAt(0) === '-') ? 'desc' : 'asc')
     }
 
+    // define default modal settings in a format that jade can access easily
+    req.linz.model.grid.recordActions.forEach(function (action) {
+
+        var modal = { active: false };
+
+        if (typeof action.modal === 'object') {
+            modal = action.modal;
+            modal.active = true;
+        } else if (typeof action.modal === 'boolean') {
+            modal.active = action.modal;
+        }
+
+        action.modal = modal;
+
+    });
+
 	res.render(linz.views + '/modelIndex.jade', {
 		model: req.linz.model,
         form: req.linz.model.formData || {},

--- a/views/modelIndex/records.jade
+++ b/views/modelIndex/records.jade
@@ -51,9 +51,9 @@ if records.length > 0
 																li(role='presentation', class='divider')
 															else
 																if (record.recordActions && record.recordActions[action.label] && record.recordActions[action.label].disabled)
-																	a(href='', data-linz-disabled='true', data-linz-disabled-message=record.recordActions[action.label].message, data-linz-modal=action.modal)= action.label
+																	a(href='', data-linz-disabled='true', data-linz-disabled-message=record.recordActions[action.label].message)= action.label
 																else
-																	a(href=linz.api.url.getAdminLink(model, action.action, record._id) target=action.target, data-linz-modal=action.modal)= action.label
+																	a(href=linz.api.url.getAdminLink(model, action.action, record._id) target=action.target, data-linz-modal=action.modal.active data-linz-modal-callback=action.modal.callback)= action.label
 
 							each val in Object.keys(model.grid.columns)
 								td!= record['rendered'][val]

--- a/views/modelIndex/records.jade
+++ b/views/modelIndex/records.jade
@@ -51,9 +51,9 @@ if records.length > 0
 																li(role='presentation', class='divider')
 															else
 																if (record.recordActions && record.recordActions[action.label] && record.recordActions[action.label].disabled)
-																	a(href='', data-linz-disabled='true', data-linz-disabled-message=record.recordActions[action.label].message)= action.label
+																	a(href='', data-linz-disabled='true', data-linz-disabled-message=record.recordActions[action.label].message, data-linz-modal=action.modal)= action.label
 																else
-																	a(href=linz.api.url.getAdminLink(model, action.action, record._id) target=action.target)= action.label
+																	a(href=linz.api.url.getAdminLink(model, action.action, record._id) target=action.target, data-linz-modal=action.modal)= action.label
 
 							each val in Object.keys(model.grid.columns)
 								td!= record['rendered'][val]


### PR DESCRIPTION
This PR improves linz modal support where you can load a bootstrap modal by setting ```data-linz-modal="true"``` attribute in your html ```a``` or ```button``` tag.

linz modal also includes form validation by adding ```data-linz-validation="true"``` to the ```form``` tag in the modal HTML.

@smebberson This is ready for review