### PR TITLE
Local date time cell renderer

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -30,6 +30,9 @@ var defaults = module.exports = {
     'page size': 20,
     'page sizes': [20,50,100,200],
 	'cookie secret': 'oST1Thr2s/iOAUgeK4yuuA==',
-	'requires login': true
+	'requires login': true,
+	'date format': 'ddd DD/MM/YYYY',
+	'datetime format': 'ddd DD/MM/YYYY h:mm A',
+	'localise time': false
 
 };

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -31,8 +31,8 @@ var defaults = module.exports = {
     'page sizes': [20,50,100,200],
 	'cookie secret': 'oST1Thr2s/iOAUgeK4yuuA==',
 	'requires login': true,
-	'date format': 'ddd DD/MM/YYYY',
-	'datetime format': 'ddd DD/MM/YYYY h:mm A',
+	'date format': 'ddd, ll',
+	'datetime format': 'llll',
 	'set local time': false
 
 };

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -33,6 +33,6 @@ var defaults = module.exports = {
 	'requires login': true,
 	'date format': 'ddd DD/MM/YYYY',
 	'datetime format': 'ddd DD/MM/YYYY h:mm A',
-	'localise time': false
+	'set local time': false
 
 };

--- a/lib/formtools/renderers-cell.js
+++ b/lib/formtools/renderers-cell.js
@@ -15,7 +15,7 @@ var dateTimeRenderer = module.exports.dateTime = function dateTimeRenderer (date
 var localDateRenderer = module.exports.localDate = function localDateRenderer (date, record, fieldName, model, callback) {
 
     if (date instanceof Date) {
-        return callback(null, '<span data-linz-localise-date data-linz-date-format="' + linz.get('date format') + '">' + date.toISOString() + '</span>');
+        return callback(null, '<time data-linz-local-date data-linz-date-format="' + linz.get('date format') + '" data-linz-utc-date="' + date.toISOString() + '"></time>');
     }
     return callback(null);
 
@@ -24,7 +24,7 @@ var localDateRenderer = module.exports.localDate = function localDateRenderer (d
 var localDateTimeRenderer = module.exports.localDateTime = function localDateTimeRenderer (date, record, fieldName, model, callback) {
 
     if (date instanceof Date) {
-        return callback(null, '<span data-linz-localise-date data-linz-date-format="' + linz.get('datetime format') + '">' + date.toISOString() + '</span>');
+        return callback(null, '<time data-linz-local-date data-linz-date-format="' + linz.get('datetime format') + '" data-linz-utc-date="' + date.toISOString() + '"></time>');
     }
     return callback(null);
 };
@@ -180,7 +180,7 @@ var defaultRenderer = module.exports.default = function defaultRenderer(val, rec
 
 	if (val instanceof Date) {
 
-        if (linz.get('localise time')) {
+        if (linz.get('set local time')) {
             return localDateRenderer(val, record, fieldName, model, callback);
         }
 

--- a/lib/formtools/renderers-cell.js
+++ b/lib/formtools/renderers-cell.js
@@ -5,7 +5,28 @@ var moment = require('moment'),
     async = require('async');
 
 var dateRenderer = module.exports.date = function dateRenderer (date, record, fieldName, model, callback) {
-    return callback(null, moment(date).format('ddd DD/MM/YYYY'));
+    return callback(null, moment(date).format(linz.get('date format')));
+};
+
+var dateTimeRenderer = module.exports.dateTime = function dateTimeRenderer (date, record, fieldName, model, callback) {
+    return callback(null, moment(date).format(linz.get('datetime format')));
+};
+
+var localDateRenderer = module.exports.localDate = function localDateRenderer (date, record, fieldName, model, callback) {
+
+    if (date instanceof Date) {
+        return callback(null, '<span data-linz-localise-date data-linz-date-format="' + linz.get('date format') + '">' + date.toISOString() + '</span>');
+    }
+    return callback(null);
+
+};
+
+var localDateTimeRenderer = module.exports.localDateTime = function localDateTimeRenderer (date, record, fieldName, model, callback) {
+
+    if (date instanceof Date) {
+        return callback(null, '<span data-linz-localise-date data-linz-date-format="' + linz.get('datetime format') + '">' + date.toISOString() + '</span>');
+    }
+    return callback(null);
 };
 
 var linkRenderer = module.exports.overviewLink = function overviewLinkRenderer (val, record, fieldName, model, callback) {
@@ -158,7 +179,13 @@ var defaultRenderer = module.exports.default = function defaultRenderer(val, rec
     }
 
 	if (val instanceof Date) {
+
+        if (linz.get('localise time')) {
+            return localDateRenderer(val, record, fieldName, model, callback);
+        }
+
         return dateRenderer(val, record, fieldName, model, callback);
+
     }
 
     if (val !== '' && utils.isBoolean(val)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -101,3 +101,12 @@ exports.arrayMatch = function (arr1, arr2) {
 	});
 
 };
+
+/**
+ * Escape regex special characters
+ * @param {String} str    str with special characters to escape
+ * @return {String}
+ */
+exports.escapeRegExp = function (str) {
+  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+};

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -155,10 +155,10 @@ if (!linz) {
         });
 
         // convert UTC to local datetime
-        $('[data-linz-localise-date]').each(function () {
+        $('[data-linz-local-date]').each(function () {
 
             var dateFormat = $(this).attr('data-linz-date-format') || 'ddd DD/MM/YYYY';
-            var localDateTime = moment(new Date($(this).html())).format(dateFormat);
+            var localDateTime = moment(new Date($(this).attr('data-linz-utc-date'))).format(dateFormat);
 
             $(this).html(localDateTime);
 

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -154,6 +154,16 @@ if (!linz) {
 
         });
 
+        // convert UTC to local datetime
+        $('[data-linz-localise-date]').each(function () {
+
+            var dateFormat = $(this).attr('data-linz-date-format') || 'ddd DD/MM/YYYY';
+            var localDateTime = moment(new Date($(this).html())).format(dateFormat);
+
+            $(this).html(localDateTime);
+
+        });
+
     });
 
     function loadLibraries(path) {


### PR DESCRIPTION
This PR adds the ability to render local datetime using client side scripting.
Linz will now allow customisation for:
- date format
- datetime format
- localise date by default

This configuration can change when initialising the application. See linz ```default.js``` for the default values.

This PR also includes 3 other date renderers, they are:
- ```dateTimeRenderer```
- ```localDateRenderer```
- ```localDateTimeRenderer```