### PR TITLE
Redirect after login

### DIFF
--- a/lib/api/url.js
+++ b/lib/api/url.js
@@ -56,7 +56,7 @@ exports.getAdminLink = function (obj, action, id) {
 
 };
 
-exports.getLink = function (links) {
+exports.getLink = function () {
 
     var url = linz.get('admin path');
 
@@ -65,10 +65,12 @@ exports.getLink = function (links) {
         return url;
     }
 
-    links.forEach(function (link, index) {
-        url += (index < links.length) ? '/' : '';
-        url += link;
-    });
+    for (var i = 0; i < arguments.length; i++) {
+
+        url += (i < arguments.length) ? '/' : '';
+        url += arguments[i];
+
+    }
 
     return url;
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -34,7 +34,7 @@ var defaults = module.exports = {
 	'datetime format': 'llll',
 	'set local time': false,
 	'permissions': function defaultPermissions (userId, action, context, callback) {
-		return callback(null, true);
+		return callback(true);
 	},
 
 	'disable navigation cache' : false,

--- a/lib/helpers-configs.js
+++ b/lib/helpers-configs.js
@@ -5,7 +5,7 @@ var path = require('path'),
 
 exports.loadConfigs = function loadConfigs (dir) {
 
-	debugConfigs('Loading configs from directory, %s', dir);
+	debugConfigs('Attemping to load configs from directory, %s', dir);
 
 	var dir = path.resolve(process.cwd(), dir),
 		files = [],
@@ -14,6 +14,13 @@ exports.loadConfigs = function loadConfigs (dir) {
     try {
         files = fs.readdirSync(dir);
     } catch (e) {
+
+		// handle the case in which configs did not exist (common on early setups)
+		if (e.code === 'ENOENT') {
+			debugConfigs('Configs directory %s did not exist, no configs loaded', dir);
+			return configs;
+		}
+
         debugConfigs('Error: Unable to load configs from directory, %s', dir);
         error.log(e.stack + '\n');
         return configs;

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,0 +1,15 @@
+var linz = require('../');
+
+// this will mount middleware that needs to exist across all routes, not just admin routes
+exports.mountDefaults = function (app) {
+
+    app.use(require('../middleware/request')());
+
+};
+
+// this will mount middleware spefific to the admin router (i.e. only routes beinging with /admin)
+exports.mountAdminMiddleware = function (router) {
+
+    router.use(linz.middleware.originalUrl());
+
+};

--- a/lib/router.js
+++ b/lib/router.js
@@ -31,7 +31,7 @@ exports.setupAdminRoutes = function () {
 	router.post('*', middleware.linz, linz.middleware.exclusions(middleware.adminEnsureAuthenticated(), middleware.navigation));
 	router.get('/', routes.adminHome);
 	router.get('/login', routes.adminLogin.get);
-	router.post('/login', linz.passport.authenticate('linz-local', { failureRedirect: linz.get('admin path') + '/login' }), routes.adminLogin.post);
+	router.post('/login', linz.middleware.authenticate('linz-local'));
 	router.get('/logout', routes.adminLogout);
 
 };

--- a/linz.js
+++ b/linz.js
@@ -592,7 +592,8 @@ Linz.prototype.buildNavigation = function (cb) {
 
 	var nav = [],
 		_this = this,
-		linzModels = this.get('models');
+		linzModels = this.get('models'),
+		linzConfigs = this.get('configs');
 
     // models, configs and logs
     async.parallel([
@@ -636,12 +637,16 @@ Linz.prototype.buildNavigation = function (cb) {
 
         function (done) {
 
-            // add a reference for configs
-            var configs = {
-                name: 'Configs',
-                href: _this.get('admin path') + '/configs/list'
-            };
-            nav.push(configs);
+            // add a reference for configs, if we have some
+			if (linzConfigs.length) {
+
+				var configs = {
+	                name: 'Configs',
+	                href: _this.get('admin path') + '/configs/list'
+	            };
+	            nav.push(configs);
+				
+			}
 
             return done(null);
 

--- a/middleware-public/authenticate.js
+++ b/middleware-public/authenticate.js
@@ -1,0 +1,118 @@
+var linz = require('../');
+
+/**
+ * This middleware provides a hook for those using a custom login process to remain integrated
+ * with core Linz functionality (such as redirect to original URL after login).
+ * @param  {String} strategy The name of the passport strategy to use.
+ * @param  {Object} opts     Configuration options to alter how this function works.
+ * @return {Function}        Express middleware function.
+ */
+module.exports = function (strategy, opts) {
+
+    if (!strategy) {
+        throw new Error('A passport strategy must be defined.');
+    }
+
+    opts = opts || {};
+
+    return function (req, res, next) {
+
+        // call the authenticate method, passing in the strategy, our custom call back and req, res and next
+        linz.passport.authenticate(strategy, function (err, user, info) {
+
+            // if we have an error, call next
+            if (err) {
+                return next(err);
+            }
+
+            // if there is no user, we want to offer
+            // 1. a specific redirect url
+            // 2. the ability to call next
+            // 3. default Linz operation, redirect to /admin/login
+            if (!user) {
+
+                // Does the user wan't to use req.flash to store an error message?
+                if (opts.failureFlash) {
+
+                    var flash = {};
+
+                    if (typeof opts.failureFlash === 'string') {
+                        flash = { type: 'error', message: opts.failureFlash };
+                    }
+
+                    flash.type = flash.type || 'error';
+                    flash.message = flash.message || info.message || info || 'Unauthorised';
+
+                    if (typeof flash.message === 'string') {
+                        req.flash(flash.type, flash.message);
+                    }
+
+                }
+
+                if (opts.failureRedirect) {
+                    return res.redirect(opts.failureRedirect);
+                }
+
+                if (opts.next) {
+                    return next();
+                }
+
+                return res.redirect(linz.api.url.getLink('login'));
+
+            }
+
+            // there is a user, let's log them in and then we want to offer (assuming there is no error):
+            // 1. a specific redirect url
+            // 2. the ability to call next
+            // 3. default Linz operation, redirec to res.cookies['linz-return-url'] || /admin
+            return req.login(user, function (err) {
+
+                // The default Linz redirect.
+                var defaultRedirect = linz.api.url.getLink();
+
+                if (err) {
+                    return next(err);
+                }
+
+                // Does the user wan't to use req.flash to store a success message?
+                if (opts.successFlash) {
+
+                    var flash = {};
+
+                    if (typeof opts.successFlash === 'string') {
+                        flash = { type: 'success', message: opts.successFlash };
+                    }
+
+                    flash.type = flash.type || 'success';
+                    flash.message = flash.message || info.message || info || 'Successful login';
+
+                    if (typeof flash.message === 'string') {
+                        req.flash(flash.type, flash.message);
+                    }
+
+                }
+
+                if (opts.successRedirect) {
+                    return res.redirect(opts.successRedirect);
+                }
+
+                if (opts.next) {
+                    return next();
+                }
+
+                // If we have a return url, let's use it and clear the cookie so we don't repeat
+                // this unneccessarily.
+                if (req.cookies['linz-return-url']) {
+                    defaultRedirect = req.cookies['linz-return-url'];
+                    res.clearCookie('linz-return-url');
+                }
+
+                return res.redirect(defaultRedirect);
+
+            });
+
+        })(req, res, next);
+
+    }
+
+}

--- a/middleware-public/exclusions.js
+++ b/middleware-public/exclusions.js
@@ -8,7 +8,7 @@ module.exports = function () {
     }
 
     var args = Array.prototype.slice.call(arguments),
-        exclusions = [new RegExp("^" + "/admin".replace(/\//g, '\/') + "\/(login|logout|public)")], // TODO: change /admin to linz.get('admin path')
+        exclusions = [new RegExp("^" + linz.api.url.getLink().replace(/\//g, '\/') + "\/(login|logout|public)")],
         middlewares = args;
 
     if (Array.isArray(args[0]) && args.length === 1) {
@@ -16,7 +16,7 @@ module.exports = function () {
     }
 
     if (Array.isArray(args[0])) {
-        exclusions = args[0];
+        exclusions = exclusions.concat(args[0]);
         // remove the first arguments as this is an exclusion
         middlewares.splice(0,1);
     }

--- a/middleware-public/index.js
+++ b/middleware-public/index.js
@@ -4,3 +4,5 @@ exports.responseTime = require('./response-time');
 exports.logError = require('./log-error');
 exports.error = require('./error');
 exports.exclusions = require('./exclusions');
+exports.originalUrl = require('./original-url');
+exports.authenticate = require('./authenticate');

--- a/middleware-public/original-url.js
+++ b/middleware-public/original-url.js
@@ -1,0 +1,27 @@
+var linz = require('../'),
+	passport = require('passport'),
+    exclusions = require('./exclusions');
+
+/**
+ * This is a very simple middleware and is used to persist the original url a user requested.
+ * This is exposed, and used within Linz login handling so that customised login processes can still
+ * benefit from built-in Linz login functionality (such as redirecting to a previously protected route).
+ * This middleware is wrapped in the exclusions middleware so that it doesn't execute for /admin/login, etc.
+ */
+module.exports = function (customExclusions) {
+
+	customExclusions = customExclusions || [];
+
+	customExclusions = customExclusions.concat(new RegExp('^' + linz.api.url.getLink().replace(/\//g, '\/') + '\/?$'));
+
+	return exclusions(customExclusions, function (req, res, next) {
+
+		if (!req.isAuthenticated()) {
+			res.cookie('linz-return-url', req.originalUrl, { path: '/',  httpOnly: true });
+		}
+
+		return next();
+
+	})
+
+};

--- a/routes/adminLogin.js
+++ b/routes/adminLogin.js
@@ -40,10 +40,6 @@ var route = {
 
         });
 
-	},
-
-	post: function (req, res) {
-		res.redirect((linz.get('admin path') === '' ? '/': linz.get('admin path')));
 	}
 
 };


### PR DESCRIPTION
This PR will redirect the user after successful login to the original request url they were attempting to resolve if the request is hijacked by the authorisation middleware.

To recreate:

- make sure you're logged out of Linz
- enter a protected URL in your browser (not `/admin/models/list` as that is the default)
- you'll be redirected to the login screen
- login to Linz
- after login, you should be on the protected URL you original entered rather than `/admin/models/list`

Further testing:

- [x] user should be redirected to original URL if they attempted to resolve a protected URL while logged out
- [x] should not break current functionality, such as redirecting to the default Linz admin url of `/admin/models/list`

To test this against a plain Linz setup, use the recently updated repository https://github.com/smebberson/linz-minitwitter-basic. It comes with a Vagrant setup for easy installation.